### PR TITLE
THT file disable-panko.yml no longer exists

### DIFF
--- a/plugins/tripleo-overcloud/vars/overcloud/templates/ceilometer-write-qdr-edge-only.yml
+++ b/plugins/tripleo-overcloud/vars/overcloud/templates/ceilometer-write-qdr-edge-only.yml
@@ -2,4 +2,3 @@
 tripleo_heat_templates:
     - "{{ install.heat.templates.basedir }}/environments/metrics/ceilometer-write-qdr.yaml"
     - "{{ install.heat.templates.basedir }}/environments/metrics/qdr-edge-only.yaml"
-    - "{{ install.heat.templates.basedir }}/environments/disable-panko.yaml"

--- a/plugins/tripleo-overcloud/vars/overcloud/templates/ceilometer-write-qdr-mesh.yml
+++ b/plugins/tripleo-overcloud/vars/overcloud/templates/ceilometer-write-qdr-mesh.yml
@@ -2,4 +2,3 @@
 tripleo_heat_templates:
     - "{{ install.heat.templates.basedir }}/environments/metrics/ceilometer-write-qdr.yaml"
     - "{{ install.heat.templates.basedir }}/environments/metrics/qdr-form-controller-mesh.yaml"
-    - "{{ install.heat.templates.basedir }}/environments/disable-panko.yaml"


### PR DESCRIPTION
Remove reference to disable-panko.yml THT file in templates because it
no longer exists.
